### PR TITLE
Removing weird space character

### DIFF
--- a/src/epub/text/chapter-9.xhtml
+++ b/src/epub/text/chapter-9.xhtml
@@ -98,7 +98,7 @@
 			</blockquote>
 			<blockquote epub:type="z3998:letter">
 				<header>
-					<p>Letter, Abraham Van Helsing, <abbr class="degree">MD</abbr>, <abbr class="degree">D. Ph.</abbr>, <abbr class="degree">D. Lit.</abbr>, <abbr>etc.</abbr>, <abbr>etc.</abbr>, to <abbr>Dr.</abbr> Seward.</p>
+					<p>Letter, Abraham Van Helsing, <abbr class="degree">MD</abbr>, <abbr class="degree">D. Ph.</abbr>, <abbr class="degree">D. Lit.</abbr>, <abbr>etc.</abbr>, <abbr>etc.</abbr>, to <abbr>Dr.</abbr> Seward.</p>
 				</header>
 				<p epub:type="se:letter.dateline">“<i>2 September.</i></p>
 				<p epub:type="z3998:salutation">“My good Friend⁠—</p>


### PR DESCRIPTION
There appears to be a weird space character between D. and Ph. It appears like this in my Kobo reader

![20200707_112514](https://user-images.githubusercontent.com/1032782/86748298-06591800-c045-11ea-94b3-c05990cebac8.jpg)
